### PR TITLE
Add support for vacation and sick days in Hilan

### DIFF
--- a/src/scrapers/impl/HilanScraper.ts
+++ b/src/scrapers/impl/HilanScraper.ts
@@ -110,17 +110,16 @@ export class HilanScraper extends Scraper {
 			return {
 				dayValue: dayValue as DayValue,
 				hours: resolvedHours.hours,
-				isSickDay: resolvedHours.isSickDay,
-				isVacation: resolvedHours.isVacation,
+				modifier: resolvedHours.modifier,
 			};
 		});
 
 		if (!this.config.dayModifiersSupport.sickDays) {
-			normalizedDays = normalizedDays.filter((day) => !day.isSickDay);
+			normalizedDays = normalizedDays.filter((day) => day.modifier !== DayModifiers.SICK_DAY);
 		}
 
 		if (!this.config.dayModifiersSupport.vacation) {
-			normalizedDays = normalizedDays.filter((day) => !day.isVacation);
+			normalizedDays = normalizedDays.filter((day) => day.modifier !== DayModifiers.VACATION);
 		}
 
 		return normalizedDays;
@@ -175,7 +174,6 @@ export class HilanScraper extends Scraper {
 					const [inHour, outHour] = row.hours;
 					const dayModifier = this.resolveSelectTitle(row.selectElementTitle);
 
-					// add support for vacation/sick days
 					if ((!stringIsHourBase(inHour) || !stringIsHourBase(outHour)) && dayModifier === null) {
 						throw new ScrapingError(`Malformed hour for day ${row.day}`);
 					}
@@ -184,8 +182,7 @@ export class HilanScraper extends Scraper {
 					dayHashMap[row.day].push({
 						in: inHour,
 						out: outHour,
-						isSickDay: dayModifier === DayModifiers.SICK_DAY,
-						isVacation: dayModifier === DayModifiers.VACATION,
+						modifier: dayModifier,
 					});
 				}
 
@@ -202,8 +199,7 @@ export class HilanScraper extends Scraper {
 
 		return {
 			hours: hours[0],
-			isSickDay: hours[0].isSickDay,
-			isVacation: hours[0].isVacation,
+			modifier: hours[0].modifier,
 		};
 	}
 

--- a/src/scrapers/types/CommonScrapingTypes.ts
+++ b/src/scrapers/types/CommonScrapingTypes.ts
@@ -6,14 +6,7 @@ export interface RawDayRow {
 	selectElementTitle?: string;
 }
 
-export interface RawDayRowWithDayModifier {
-	day?: DayValue;
-	hours: Hour[];
-	isVacation: boolean;
-	isSickDay: boolean;
-}
-
 export enum DayModifiers {
-	SICK_DAY,
-	VACATION,
+	SICK_DAY = 'sickDay',
+	VACATION = 'vacation',
 }

--- a/src/types/hours.ts
+++ b/src/types/hours.ts
@@ -1,11 +1,12 @@
+import { DayModifiers } from '../scrapers/types/CommonScrapingTypes';
+
 export type Hour = `${number}:${number}`;
 export type DayValue = `${ValidDay}/${ValidMonth}`;
 
 export interface Day {
 	dayValue: DayValue;
 	hours: DayHours;
-	isVacation?: boolean;
-	isSickDay?: boolean;
+	modifier: DayModifiers | null;
 }
 
 export interface DayHours {
@@ -14,8 +15,7 @@ export interface DayHours {
 }
 
 export interface DayHoursWithDayModifier extends DayHours {
-	isVacation: boolean;
-	isSickDay: boolean;
+	modifier: DayModifiers | null;
 }
 
 export type ValidDay =


### PR DESCRIPTION
Implement functionality to handle vacation and sick days within the Hilan scraper, while simplifying day modifiers and cleaning up the codebase.