### PR TITLE
Adjust hour inputting logic

### DIFF
--- a/src/clients/automators/impl/WebtimeAutomator.ts
+++ b/src/clients/automators/impl/WebtimeAutomator.ts
@@ -139,36 +139,45 @@ export class WebtimeAutomator extends Automator {
 	}
 
 	private async handleFillHourInputsStartAndEnd(
-		rows: ElementHandle<Element>[],
-		hours: DayHours[],
-		onSuccessfulInput: () => void,
-	) {
-		for (const index in rows) {
-			const row = rows[index];
-			const { start, end } = this.getPossiblyPartialHoursSelector();
-			const [hourIn, minuteIn] = getSafeHourAndMinute(hours[index].in);
-			const [hourOut, minuteOut] = getSafeHourAndMinute(hours[index].out);
+    rows: ElementHandle<Element>[],
+    hours: DayHours[],
+    onSuccessfulInput: () => void,
+) {
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        const dayHours = hours[i];
+        if (!dayHours) continue;
 
-			const defaultOptions: DefaultFillInputOptions = {
-				handler: row,
-				earlyReturnOnNonEmpty: true,
-			};
+        const { start, end } = this.getPossiblyPartialHoursSelector();
+        const [hourIn, minuteIn] = getSafeHourAndMinute(dayHours.in);
+        const [hourOut, minuteOut] = getSafeHourAndMinute(dayHours.out);
 
-			const inputValuesPromises = [
-				{ inputSelector: start.hour, inputValue: hourIn },
-				{ inputSelector: start.minute, inputValue: minuteIn },
-				{ inputSelector: end.hour, inputValue: hourOut },
-				{ inputSelector: end.minute, inputValue: minuteOut },
-				// TODO: switch to LoginInputStrategy
-			].map((values) => fillInputByPartialId({ ...defaultOptions, ...values }));
+        const baseOptions: DefaultFillInputOptions = {
+            handler: row,
+            earlyReturnOnNonEmpty: true,
+        };
 
-			const results = await Promise.all(inputValuesPromises);
+        const inputs = [
+            { inputSelector: start.hour, inputValue: hourIn },
+            { inputSelector: start.minute, inputValue: minuteIn },
+            { inputSelector: end.hour, inputValue: hourOut },
+            { inputSelector: end.minute, inputValue: minuteOut },
+        ];
 
-			if (results.some(Boolean)) {
-				onSuccessfulInput();
-			}
-		}
-	}
+        const inputSuccessArray = [];
+
+        for (const input of inputs) {
+            inputSuccessArray.push(await fillInputByPartialId({
+                ...baseOptions,
+                ...input,
+            }));
+        }
+
+        if (inputSuccessArray.some(Boolean)) {
+            onSuccessfulInput();
+        }
+    }
+}
 
 	private async selectAssignmentValue(page: Page, dayType: DayType) {
 		const selectElement = await page.$('#assignments');

--- a/src/clients/scrapers/impl/HilanScraper.ts
+++ b/src/clients/scrapers/impl/HilanScraper.ts
@@ -95,9 +95,11 @@ export class HilanScraper extends Scraper {
 			await element.click();
 		}
 
-		// unmark current day, as the empty value can break next functions.
-		// TODO current day might interest us if split days. Implement eventually.
-		await page.click('.currentDay');
+		/** 
+		TODO current day might interest us if split days. Implement eventually.
+		For now, we unmark current day, as the empty/non-even value can break next functions. 
+		**/
+		// await page.click('.currentDay');
 
 		await page.click('input[id*=RefreshSelectedDays]');
 

--- a/src/converters/day2GroupedDays.ts
+++ b/src/converters/day2GroupedDays.ts
@@ -14,6 +14,7 @@ export function day2GroupedDays(days: Day[]): GroupedDays {
 	};
 
 	for (const day of days) {
+		if (!day.dayType) continue;
 		record[day.dayType].push(day);
 	}
 


### PR DESCRIPTION
The following PR addresses and closes #60 

The main issue was addressed by rewriting the hour input function in `webtime`, so it will be deterministic and allow the handlers to operate sequentially.

Also, I've commented out the part that includes the current day in `hilan`. We currently don't care about the current day.
Also fixed possible future bugs in the day grouping function.